### PR TITLE
Added some support for 3d plots

### DIFF
--- a/src/PGFPlots.jl
+++ b/src/PGFPlots.jl
@@ -82,6 +82,19 @@ type Axis
     new(plots, title, xlabel, ylabel, xmin, xmax, ymin, ymax, enlargelimits, axisOnTop, view, width, height, style, legendPos
   )
 
+  # Constructors specifically for 3d plot case
+  # The only difference here is that the view is not defaulted to a 2d view
+  # Come to think of it, is there any reason the view is forced to be {0}{90}? 
+  #  Won't it figure it out on its own?
+  Axis(plot::Linear3;title=nothing, xlabel=nothing, ylabel=nothing, xmin=nothing, xmax=nothing,
+       ymin=nothing, ymax=nothing, enlargelimits=nothing, axisOnTop=nothing, view=nothing, width=nothing, height=nothing, style=nothing, legendPos=nothing) =
+    new([plot], title, xlabel, ylabel, xmin, xmax, ymin, ymax, enlargelimits, axisOnTop, view, width, height, style, legendPos
+  )
+  Axis(plots::Vector{Linear3};title=nothing, xlabel=nothing, ylabel=nothing, xmin=nothing, xmax=nothing,
+       ymin=nothing, ymax=nothing, enlargelimits=nothing, axisOnTop=nothing, view=nothing, width=nothing, height=nothing, style=nothing, legendPos=nothing) =
+    new(plots, title, xlabel, ylabel, xmin, xmax, ymin, ymax, enlargelimits, axisOnTop, view, width, height, style, legendPos
+  )
+
 end
 
 type PolarAxis
@@ -237,6 +250,21 @@ function plotHelper(o::IOBuffer, p::Linear)
   end
 end
 
+# Specific version for Linear3 type 
+# Changes are addplot3 (vs addplot) and iterate over all 3 columns
+function plotHelper(o::IOBuffer, p::Linear3)
+  print(o, "\\addplot3+ ")
+  optionHelper(o, linearMap, p, brackets=true)
+  println(o, "coordinates {")
+  for i = 1:size(p.data,2)
+    println(o, "($(p.data[1,i]), $(p.data[2,i]), $(p.data[3,i]))")
+  end
+  println(o, "};")
+  if p.legendentry != nothing
+    println(o, "\\addlegendentry{$(p.legendentry)}")
+  end
+end
+
 function plotHelper(o::IOBuffer, p::Node)
   if p.style != nothing
     println(o, "\\node at (axis cs:$(p.x), $(p.y)) [$(p.style)] {$(p.data)};")
@@ -344,6 +372,8 @@ typealias Plottable Union(Plot,GroupPlot,Axis,PolarAxis)
 plot(p::Plot) = plot(Axis(p))
 
 plot{A<:Real,B<:Real}(x::AbstractArray{A,1}, y::AbstractArray{B,1}) = plot(Linear(x, y))
+
+plot{A<:Real,B<:Real,C<:Real}(x::AbstractVector{A}, y::AbstractVector{B}, z::AbstractVector{C}) = plot(Linear3(x, y, z))
 
 function Plots.Linear(f::Function, range::(Real,Real); mark="none", style=nothing, legendentry=nothing)
   x = linspace(range[1], range[2])

--- a/src/plots.jl
+++ b/src/plots.jl
@@ -1,6 +1,6 @@
 module Plots
 
-export Plot, Histogram, Linear, ErrorBars, Image, Contour, Scatter, Quiver, Node
+export Plot, Histogram, Linear, Linear3, ErrorBars, Image, Contour, Scatter, Quiver, Node
 import Images: grayim, imwrite
 
 include("ndgrid.jl")
@@ -41,6 +41,15 @@ type Linear <: Plot
   legendentry
   onlyMarks
   Linear{T<:Real}(data::AbstractArray{T,2}; mark=nothing, style=nothing, legendentry=nothing, onlyMarks=nothing) = new(data, mark, style, legendentry, onlyMarks)
+end
+
+type Linear3 <: Plot
+  data::AbstractArray{Real,2}
+  mark
+  style
+  legendentry
+  onlyMarks
+  Linear3{T<:Real}(data::AbstractArray{T,2}; mark=nothing, style=nothing, legendentry=nothing, onlyMarks=nothing) = new(data, mark, style, legendentry, onlyMarks)
 end
 
 type ErrorBars <: Plot
@@ -89,7 +98,9 @@ Quiver{A<:Real,B<:Real,C<:Real,D<:Real}(x::Vector{A}, y::Vector{B}, u::Vector{C}
 
 Linear{A<:Real, B<:Real}(x::AbstractArray{A,1}, y::AbstractArray{B,1}; mark=nothing, style=nothing, legendentry=nothing, onlyMarks=nothing) = Linear([x y]', mark=mark, style=style, legendentry=legendentry, onlyMarks=onlyMarks)
 Linear{A<:Real}(data::AbstractArray{A,1}; mark=nothing, style=nothing, legendentry=nothing, onlyMarks=nothing) = Linear([1:length(data)], data, mark=mark, style=style, legendentry=legendentry, onlyMarks=onlyMarks)
-Linear{A<:Real, B<:Real}(x::AbstractArray{A,1}, y::AbstractArray{B,1}; mark=nothing, style=nothing, legendentry=nothing, onlyMarks=nothing) = Linear([x y]', mark=mark, style=style, legendentry=legendentry, onlyMarks=onlyMarks)
+
+
+Linear3{A<:Real, B<:Real, C<:Real}(x::AbstractVector{A}, y::AbstractVector{B}, z::AbstractVector{C}; mark=nothing, style=nothing, legendentry=nothing, onlyMarks=nothing) = Linear3([x y z]', mark=mark, style=style, legendentry=legendentry, onlyMarks=onlyMarks)
 
 ErrorBars{A<:Real, B<:Real, C<:Real, D<:Real, E<:Real, F<:Real}(x::AbstractArray{A,1}, y::AbstractArray{B,1}, xplus::AbstractArray{C,1}, yplus::AbstractArray{D,1},
                             xminus::AbstractArray{E,1}, yminus::AbstractArray{F,1}; mark=nothing, style=nothing, legendentry=nothing) = ErrorBars([x y xplus yplus xminus yminus]',mark=mark, style=style, legendentry=legendentry)


### PR DESCRIPTION
I've added some support for making 3d plots. To do this, I created a new plots type, Plots.Linear3. I've added a method to the plotHelper function specifically for the Plots.Linear3 type. It prints out "addplot3" and pulls the data from the three columns (rather than just the first two). I've also added a couple Axis constructors specifically for the Plots.Linear type. The only difference between these and previous is that no default view is set. The current constructors for axis specify a view of {0}{90}, essentially enforcing 2d plots. I'm not sure specifying that is necessary--I think pgfplots will default to that. If we don't enforce the {0}{90} view, then we don't need the two Axis constructors I've added.

The fields in Plots.Linear3 are identical to those of Plots.Linear (of course, the data array will have 3 columns instead of 2). The reason for making it its own type is to make cleaner methods. The other option is to check for the size of the data matrix before doing things like adding "addplot" vs "addplot3", iterating over data, or setting the view. I went with the separate type option to avoid that. We can do it the other way if anyone has strong feelings about it. I will add documentation once this has been decided.