### PR TITLE
Fix Linear3 infinite recursion.

### DIFF
--- a/src/PGFPlots.jl
+++ b/src/PGFPlots.jl
@@ -148,21 +148,16 @@ type Axis
 	axisLines
 
     Axis{P <: Plot}(plots::Vector{P};title=nothing, xlabel=nothing, ylabel=nothing, zlabel=nothing, xmin=nothing, xmax=nothing,
-                    ymin=nothing, ymax=nothing, axisEqual=nothing, axisEqualImage=nothing, enlargelimits=nothing, axisOnTop=nothing, view="{0}{90}", width=nothing,
+                    ymin=nothing, ymax=nothing, axisEqual=nothing, axisEqualImage=nothing, enlargelimits=nothing, axisOnTop=nothing, view=nothing, width=nothing,
                     height=nothing, style=nothing, legendPos=nothing, xmode=nothing, ymode=nothing, colorbar=nothing, hideAxis=nothing, axisLines=nothing) =
         new(plots, title, xlabel, ylabel, zlabel, xmin, xmax, ymin, ymax, axisEqual, axisEqualImage, enlargelimits, axisOnTop, view, width, height, style, legendPos, xmode, ymode, colorbar, hideAxis, axisLines
             )
-            
+
     Axis(;kwargs...) = Axis(Plot[]; kwargs...)
     Axis(plot::Plot; kwargs...) = Axis(Plot[plot]; kwargs...)
-        
-    # Constructors specifically for 3d plot case
-    # The only difference here is that the view is not defaulted to a 2d view
-    # Come to think of it, is there any reason the view is forced to be {0}{90}?
-    #  Won't it figure it out on its own?
-    Axis(plot::Linear3; kwargs...) = Axis(Plot[plot]; kwargs..., view=nothing)
-    Axis(plots::Vector{Linear3}; kwargs...) = Axis(plots; kwargs..., view=nothing)        
-    
+
+    Axis(plot::Contour; kwargs...) = Axis(Plot[plot]; kwargs..., view="{0}{90}")
+    Axis(plots::Vector{Contour}; kwargs...) = Axis(Plot[plots...]; kwargs..., view="{0}{90}")
 end
 typealias Axes Vector{Axis}
 
@@ -500,12 +495,12 @@ end
 
 function plot(axes::Axes)
     o = IOBuffer()
-    
+
     for axis in axes
         print(o, "\\begin{axis}")
         plotHelper(o, axis)
         println(o, "\\end{axis}")
-    end        
+    end
     TikzPicture(takebuf_string(o), options=pgfplotsoptions(), preamble=pgfplotspreamble())
 end
 


### PR DESCRIPTION
As mentioned in the original comments, the only reason for the specialized method for `Linear3` is the 2D viewing angle set as default. However, as also noted in the comment, this is unnecessary. Setting `view=nothing` in the generic constructor, and removing the two specialized constructors fixes the infinite recursion when plotting several `Linear3` plots at once, as https://github.com/sisl/PGFPlots.jl/compare/master...pkofod:recursion?expand=1#diff-6498db6e821078dd686d4e5ad083608eL164 ends up calling itself recursively, and does nothing to 2D plots.

**Edit**
I could have just fixed the `Plot[plots...]` thing for Linear3, but I think it makes more sense to have `view=nothing` as the default, and then special case `Contour`. In PGFPlots, a contour is a 3D plot, but I think that's rather unusual. If PGFPlots.jl should interface to the 3D version, I think it would only require to define a `Contour3` type, and have this default to the  `view=nothing` along with all the rest of the plots. 

Fixing this, allows https://github.com/tbreloff/Plots.jl/pull/166 to proceed.