### PR TITLE
Use dirname(@__FILE__) rather than Pkg.dir

### DIFF
--- a/src/PGFPlots.jl
+++ b/src/PGFPlots.jl
@@ -37,7 +37,7 @@ end
 
 pgfplotsoptions() = join(_pgfplotsoptions, ",\n")
 
-_pgfplotspreamble = Any[readall(joinpath(Pkg.dir("PGFPlots"), "src", "preamble.tex"))]
+_pgfplotspreamble = Any[readall(joinpath(dirname(@__FILE__), "preamble.tex"))]
 
 pushPGFPlotsPreamble(preamble::AbstractString) = push!(_pgfplotspreamble, preamble)
 function popPGFPlotsPreamble()

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,0 +1,1 @@
+NBInclude

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,5 @@ using PGFPlots
 using Base.Test
 
 @assert success(`lualatex -v`)
-Pkg.add("NBInclude")
 using NBInclude
-nbinclude(Pkg.dir("PGFPlots", "doc", "PGFPlots.ipynb"))
+nbinclude(joinpath(dirname(@__FILE__), "..", "doc", "PGFPlots.ipynb"))


### PR DESCRIPTION
so that the package can be installed elsewhere.

Use test/REQUIRE instead of calling Pkg.add so
test-only dependencies get removed if no longer needed,
rather than installing packages the user may not want.