### PR TITLE
Preamble and epilogue to plot

### DIFF
--- a/src/PGFPlots.jl
+++ b/src/PGFPlots.jl
@@ -412,6 +412,7 @@ function plotHelperErrorBars(o::IOBuffer, p::Linear)
 end
 
 function plotHelper(o::IOBuffer, p::Linear)
+    print(o, p.preamble)
     print(o, "\\addplot+ ")
     if p.errorBars == nothing
         optionHelper(o, linearMap, p, brackets=true)
@@ -424,9 +425,11 @@ function plotHelper(o::IOBuffer, p::Linear)
         plotHelperErrorBars(o, p)
     end
     plotLegend(o, p.legendentry)
+    print(o, p.epilogue)
 end
 
 function plotHelper(o::IOBuffer, p::Scatter)
+    print(o, p.preamble)
     if p.scatterClasses == nothing
         print(o, "\\addplot+[scatter, scatter src=explicit, ")
     else
@@ -439,11 +442,13 @@ function plotHelper(o::IOBuffer, p::Scatter)
     end
     println(o, "};")
     plotLegend(o, p.legendentry)
+    print(o, p.epilogue)
 end
 
 # Specific version for Linear3 type
 # Changes are addplot3 (vs addplot) and iterate over all 3 columns
 function plotHelper(o::IOBuffer, p::Linear3)
+    print(o, p.preamble)
     print(o, "\\addplot3+ ")
     optionHelper(o, linearMap, p, brackets=true)
     println(o, "coordinates {")
@@ -452,10 +457,11 @@ function plotHelper(o::IOBuffer, p::Linear3)
     end
     println(o, "};")
     plotLegend(o, p.legendentry)
+    print(o, p.epilogue)
 end
 
 function plotHelper(o::IOBuffer, p::Node)
-
+    print(o, p.preamble)
     axis = p.axis != nothing ? p.axis : "axis cs"
 
     if p.style != nothing
@@ -463,10 +469,12 @@ function plotHelper(o::IOBuffer, p::Node)
     else
         println(o, "\\node at ($(axis):$(p.x), $(p.y)) {$(p.data)};")
     end
+    print(o, p.epilogue)
 end
 
 
 function plotHelper(o::IOBuffer, p::ErrorBars)
+    print(o, p.preamble)
     print(o, "\\addplot+ [")
     optionHelper(o, errorbarsMap, p)
     print(o, ",error bars/.cd, x dir=both, x explicit, y dir=both, y explicit")
@@ -477,9 +485,11 @@ function plotHelper(o::IOBuffer, p::ErrorBars)
     end
     println(o, "};")
     plotLegend(o, p.legendentry)
+    print(o, p.epilogue)
 end
 
 function plotHelper(o::IOBuffer, p::Quiver)
+    print(o, p.preamble)
     print(o, "\\addplot+ ")
     optionHelper(o, quiverMap, p, brackets=true, otherOptions=Dict("quiver"=>"{u=\\thisrow{u},v=\\thisrow{v}}"))
     println(o, "table {")
@@ -489,9 +499,11 @@ function plotHelper(o::IOBuffer, p::Quiver)
     end
     println(o, "};")
     plotLegend(o, p.legendentry)
+    print(o, p.epilogue)
 end
 
 function plotHelper(o::IOBuffer, p::Contour)
+    print(o, p.preamble)
     arg = 5
     if p.number != nothing
         arg = p.number
@@ -525,22 +537,27 @@ function plotHelper(o::IOBuffer, p::Contour)
         end
     end
     println(o, "};")
+    print(o, p.epilogue)
 end
 
 function plotHelper(o::IOBuffer, p::Circle)
+    print(o, p.preamble)
     if p.style != nothing
         println(o, "\\draw[$(p.style)] (axis cs:$(p.xc), $(p.yc)) circle[radius=$(p.radius)];")
     else
         println(o, "\\draw (axis cs:$(p.xc), $(p.yc)) circle[radius=$(p.radius)];")
     end
+    print(o, p.epilogue)
 end
 
 function plotHelper(o::IOBuffer, p::Ellipse)
+    print(o, p.preamble)
     if p.style != nothing
         println(o, "\\draw[$(p.style)] (axis cs:$(p.xc), $(p.yc)) ellipse[x radius=$(p.xradius), y radius=$(p.yradius)];")
     else
         println(o, "\\draw (axis cs:$(p.xc), $(p.yc)) ellipse[x radius=$(p.xradius), y radius=$(p.yradius)];")
     end
+    print(o, p.epilogue)
 end
 
 function plotHelper(o::IOBuffer, p::Command)
@@ -548,6 +565,7 @@ function plotHelper(o::IOBuffer, p::Command)
 end
 
 function plotHelper(o::IOBuffer, p::Image)
+    print(o, p.preamble)
     if p.zmin == p.zmax
         error("Your colorbar range limits must not be equal to each other.")
     end
@@ -556,6 +574,7 @@ function plotHelper(o::IOBuffer, p::Image)
     else
         println(o, "\\addplot [point meta min=$(p.zmin), point meta max=$(p.zmax)] graphics [xmin=$(p.xmin), xmax=$(p.xmax), ymin=$(p.ymin), ymax=$(p.ymax)] {$(p.filename)};")
     end
+    print(o, p.epilogue)
 end
 
 function plotHelper{R<:Real}(o::IOBuffer, p::Patch2D{R})

--- a/src/plots.jl
+++ b/src/plots.jl
@@ -75,7 +75,7 @@ type Histogram <: Plot
     discretization::Symbol
     preamble
     epilogue
-    Histogram(data; bins=10, discretization=:default, density=false, cumulative=false, style="fill=blue!10") = new(data,bins,density,cumulative,style,discretization,preamble,epilogue)
+    Histogram(data; bins=10, discretization=:default, density=false, cumulative=false, style="fill=blue!10", preamble=nothing, epilogue=nothing) = new(data,bins,density,cumulative,style,discretization,preamble,epilogue)
 end
 
 type Contour <: Plot
@@ -89,7 +89,7 @@ type Contour <: Plot
     preamble
     epilogue
     Contour(data, xbins, ybins; style=nothing, number=nothing, levels=nothing, labels=nothing, preamble=nothing, epilogue=nothing) = new(data, xbins, ybins, style, number, levels, labels,preamble,epilogue)
-    function Contour(f::Function, xrange::RealRange, yrange::RealRange; xbins=40, ybins=40, style=nothing, number=nothing, levels=nothing, labels=nothing)
+    function Contour(f::Function, xrange::RealRange, yrange::RealRange; xbins=40, ybins=40, style=nothing, number=nothing, levels=nothing, labels=nothing, preamble=nothing, epilogue=nothing)
         x = linspace(xrange[1], xrange[2], xbins)
         y = linspace(yrange[1], yrange[2], ybins)
         A = zeros(xbins, ybins)
@@ -98,7 +98,7 @@ type Contour <: Plot
         catch
             A = Float64[f([xi,yi]) for xi in x, yi in y]
         end
-        new(A, x, y, style, number, levels, labels)
+        new(A, x, y, style, number, levels, labels, preamble, epilogue)
     end
 end
 
@@ -114,7 +114,7 @@ type Scatter <: Plot
     epilogue
     function Scatter{T<:Any}(data::AbstractMatrix{T}; mark=nothing, markSize=nothing, style=nothing, onlyMarks=true, legendentry=nothing, scatterClasses=nothing, preamble=nothing, epilogue=nothing)
         if size(data,1) == 2
-            return Linear(data, mark=mark, markSize=markSize, style=style, onlyMarks=onlyMarks, legendentry=legendentry,preamble,epilogue)
+            return Linear(data, mark=mark, markSize=markSize, style=style, onlyMarks=onlyMarks, legendentry=legendentry,preamble=preamble,epilogue=epilogue)
         else
             return new(data, mark, markSize, style, legendentry, onlyMarks, scatterClasses,preamble,epilogue)
         end
@@ -238,7 +238,7 @@ type Image <: Plot
         (X, Y) = meshgrid(x, y)
         A = map(f, X, Y)
         A = flipdim(A, 1)
-        Image(A, xrange, yrange, filename=filename, colorbar=colorbar, colormap=colormap, zmin=zmin, zmax=zmax, style=style, preamble, epilogue)
+        Image(A, xrange, yrange, filename=filename, colorbar=colorbar, colormap=colormap, zmin=zmin, zmax=zmax, style=style, preamble=preamble, epilogue=epilogue)
     end
 end
 

--- a/src/plots.jl
+++ b/src/plots.jl
@@ -21,7 +21,9 @@ type Linear <: Plot
     legendentry
     onlyMarks
     errorBars
-    Linear{T <: Real}(data::AbstractMatrix{T}; mark=nothing, markSize=nothing, style=nothing, legendentry=nothing, onlyMarks=nothing, errorBars=nothing) = new(data, mark, markSize, style, legendentry, onlyMarks, errorBars)
+    preamble
+    epilogue
+    Linear{T <: Real}(data::AbstractMatrix{T}; mark=nothing, markSize=nothing, style=nothing, legendentry=nothing, onlyMarks=nothing, errorBars=nothing, preamble=nothing, epilogue=nothing) = new(data, mark, markSize, style, legendentry, onlyMarks, errorBars,preamble,epilogue)
 end
 Linear{A<:Real, B<:Real}(x::AbstractVector{A}, y::AbstractVector{B}; kwargs...) = Linear(hcat(x, y)'; kwargs...)
 Linear{A<:Real}(data::AbstractVector{A}; kwargs...) = Linear(collect(1:length(data)), data; kwargs...)
@@ -33,7 +35,9 @@ type Linear3 <: Plot
     style
     legendentry
     onlyMarks
-    Linear3{T<:Real}(data::AbstractMatrix{T}; mark=nothing, markSize=nothing, style=nothing, legendentry=nothing, onlyMarks=nothing) = new(data, mark, markSize, style, legendentry, onlyMarks)
+    preamble
+    epilogue
+    Linear3{T<:Real}(data::AbstractMatrix{T}; mark=nothing, markSize=nothing, style=nothing, legendentry=nothing, onlyMarks=nothing, preamble=nothing, epilogue=nothing) = new(data, mark, markSize, style, legendentry, onlyMarks,preamble,epilogue)
 end
 Linear3{A<:Real, B<:Real, C<:Real}(x::AbstractVector{A}, y::AbstractVector{B}, z::AbstractVector{C}; kwargs...) = Linear3(hcat(x, y, z)'; kwargs...)
 
@@ -69,7 +73,9 @@ type Histogram <: Plot
     cumulative::Bool
     style::AbstractString
     discretization::Symbol
-    Histogram(data; bins=10, discretization=:default, density=false, cumulative=false, style="fill=blue!10") = new(data,bins,density,cumulative,style,discretization)
+    preamble
+    epilogue
+    Histogram(data; bins=10, discretization=:default, density=false, cumulative=false, style="fill=blue!10") = new(data,bins,density,cumulative,style,discretization,preamble,epilogue)
 end
 
 type Contour <: Plot
@@ -80,7 +86,9 @@ type Contour <: Plot
     number
     levels
     labels
-    Contour(data, xbins, ybins; style=nothing, number=nothing, levels=nothing, labels=nothing) = new(data, xbins, ybins, style, number, levels, labels)
+    preamble
+    epilogue
+    Contour(data, xbins, ybins; style=nothing, number=nothing, levels=nothing, labels=nothing, preamble=nothing, epilogue=nothing) = new(data, xbins, ybins, style, number, levels, labels,preamble,epilogue)
     function Contour(f::Function, xrange::RealRange, yrange::RealRange; xbins=40, ybins=40, style=nothing, number=nothing, levels=nothing, labels=nothing)
         x = linspace(xrange[1], xrange[2], xbins)
         y = linspace(yrange[1], yrange[2], ybins)
@@ -102,12 +110,13 @@ type Scatter <: Plot
     legendentry
     onlyMarks
     scatterClasses
-
-    function Scatter{T<:Any}(data::AbstractMatrix{T}; mark=nothing, markSize=nothing, style=nothing, onlyMarks=true, legendentry=nothing, scatterClasses=nothing)
+    preamble
+    epilogue
+    function Scatter{T<:Any}(data::AbstractMatrix{T}; mark=nothing, markSize=nothing, style=nothing, onlyMarks=true, legendentry=nothing, scatterClasses=nothing, preamble=nothing, epilogue=nothing)
         if size(data,1) == 2
-            return Linear(data, mark=mark, markSize=markSize, style=style, onlyMarks=onlyMarks, legendentry=legendentry)
+            return Linear(data, mark=mark, markSize=markSize, style=style, onlyMarks=onlyMarks, legendentry=legendentry,preamble,epilogue)
         else
-            return new(data, mark, markSize, style, legendentry, onlyMarks, scatterClasses)
+            return new(data, mark, markSize, style, legendentry, onlyMarks, scatterClasses,preamble,epilogue)
         end
     end
 end
@@ -120,7 +129,9 @@ type Quiver <: Plot
     data::Matrix{Real}
     style
     legendentry
-    Quiver{T<:Real}(data::Matrix{T}; style=nothing, legendentry=nothing) = new(data, style, legendentry)
+    preamble
+    epilogue
+    Quiver{T<:Real}(data::Matrix{T}; style=nothing, legendentry=nothing, preamble=nothing, epilogue=nothing) = new(data, style, legendentry,preamble,epilogue)
 end
 function Quiver(f::Function, xrange::RealRange, yrange::RealRange; style=nothing, legendentry=nothing, samples=15, normalize=true)
     x = linspace(xrange[1], xrange[2], samples)
@@ -148,7 +159,9 @@ type Node <: Plot
     x
     y
     axis # `nothing` will default to "axis cs", other options include "axis description cs", "xticklabel cs", etc.
-    Node(data, x, y; style=nothing, axis=nothing) = new(data, style, x, y, axis)
+    preamble
+    epilogue
+    Node(data, x, y; style=nothing, axis=nothing, preamble=nothing, epilogue=nothing) = new(data, style, x, y, axis,preamble,epilogue)
 end
 
 type Circle <: Plot
@@ -156,7 +169,9 @@ type Circle <: Plot
     yc
     radius
     style
-    Circle(xc=0,yc=0,radius=1;style=nothing) = new(xc,yc,radius,style)
+    preamble
+    epilogue
+    Circle(xc=0,yc=0,radius=1;style=nothing, preamble=nothing, epilogue=nothing) = new(xc,yc,radius,style,preamble,epilogue)
 end
 
 type Ellipse <: Plot
@@ -165,7 +180,9 @@ type Ellipse <: Plot
     xradius
     yradius
     style
-    Ellipse(xc=0,yc=0,xradius=1,yradius=1;style=nothing) = new(xc,yc,xradius,yradius,style)
+    preamble
+    epilogue
+    Ellipse(xc=0,yc=0,xradius=1,yradius=1;style=nothing, preamble=nothing, epilogue=nothing) = new(xc,yc,xradius,yradius,style,preamble,epilogue)
 end
 
 type Command <: Plot
@@ -186,7 +203,9 @@ type Image <: Plot
     colorbar::Bool
     colormap::ColorMaps.ColorMap
     style
-    function Image{T <: Real}(A::Matrix{T}, xrange::RealRange, yrange::RealRange; filename=nothing, colorbar=true, colormap=ColorMaps.Gray(), zmin=nothing, zmax=nothing, style=nothing)
+    preamble
+    epilogue
+    function Image{T <: Real}(A::Matrix{T}, xrange::RealRange, yrange::RealRange; filename=nothing, colorbar=true, colormap=ColorMaps.Gray(), zmin=nothing, zmax=nothing, style=nothing, preamble=nothing, epilogue=nothing)
         global _imgid
         if filename == nothing
             id=myid()*10000000000000+_imgid
@@ -211,15 +230,15 @@ type Image <: Plot
         else
             write(ColorMaps.RGBArray(colormap), A, filename)
         end
-        new(filename, xrange[1], xrange[2], yrange[1], yrange[2], zmin, zmax, colorbar, colormap, style)
+        new(filename, xrange[1], xrange[2], yrange[1], yrange[2], zmin, zmax, colorbar, colormap, style, preamble, epilogue)
     end
-    function Image(f::Function, xrange::RealRange, yrange::RealRange; filename=nothing, colorbar=true, colormap=ColorMaps.Gray(), zmin=nothing, zmax=nothing, xbins=100, ybins=100, style=nothing)
+    function Image(f::Function, xrange::RealRange, yrange::RealRange; filename=nothing, colorbar=true, colormap=ColorMaps.Gray(), zmin=nothing, zmax=nothing, xbins=100, ybins=100, style=nothing, preamble=nothing, epilogue=nothing)
         x = linspace(xrange[1], xrange[2], xbins)
         y = linspace(yrange[1], yrange[2], ybins)
         (X, Y) = meshgrid(x, y)
         A = map(f, X, Y)
         A = flipdim(A, 1)
-        Image(A, xrange, yrange, filename=filename, colorbar=colorbar, colormap=colormap, zmin=zmin, zmax=zmax, style=style)
+        Image(A, xrange, yrange, filename=filename, colorbar=colorbar, colormap=colormap, zmin=zmin, zmax=zmax, style=style, preamble, epilogue)
     end
 end
 


### PR DESCRIPTION
Hi, 
I ran into the prolem that I wanted to have multiple y axes in my plot like this: http://tex.stackexchange.com/a/42752 

The provided solution required me to add a line before and after the \addplot command 
`\addlegendimage{/pgfplots/refstyle=Hplot}\addlegendentry{$H$}` before the second plot and 
`\label{Hplot}` after the first plot. Therefore I added a little "hack" to provide them with PGFPlots.jl: I added the option to add a preamble and an epilogue to each plot. My code now looks like this:
```julia
x = [1,2,3]
y = [2,4,1]
y2=[10,90,40]
a1=Axis(Plots.Linear(x, y, epilogue = L"\label{Hplot}"))
a2=Axis(Plots.Linear(x, y2,legendentry="b", preamble = L"\addlegendimage{/pgfplots/refstyle=Hplot}\addlegendentry{$H$}"),style="axis y line*=right")
```

This results in a usable plot like this:
![unbenannt](https://cloud.githubusercontent.com/assets/1103207/19890103/eb63d7a4-a038-11e6-8066-ed7d8d3b555b.PNG)


I don't know if this is the best solution for the api, but I just wanted to share my "improvement".
