### PR TITLE
Fix deprecation warnings

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,7 +1,7 @@
 julia 0.5
 TikzPictures 0.3.4
 Images 0.6.0
-Compat 0.8.0
+Compat 0.17.0
 Colors 0.6.7
 ColorBrewer 0.3.0
 Contour 0.2.0

--- a/src/PGFPlots.jl
+++ b/src/PGFPlots.jl
@@ -1,4 +1,4 @@
-VERSION >= v"0.4.0-dev+6521" && __precompile__(true)
+__precompile__(true)
 
 module PGFPlots
 
@@ -168,8 +168,8 @@ patch2DMap = Dict(
 using .Plots
 using .ColorMaps
 
-typealias IntegerRange @compat Tuple{Integer,Integer}
-typealias RealRange @compat Tuple{Real,Real}
+const IntegerRange = @compat Tuple{Integer,Integer}
+const RealRange = @compat Tuple{Real,Real}
 
 type Axis
     plots::Vector{Plot}
@@ -216,7 +216,7 @@ end
 
 PolarAxis(args...; kwargs...) = Axis(args...; kwargs..., axisKeyword = "polaraxis")
 
-typealias Axes Vector{Axis}
+const Axes = Vector{Axis}
 
 function Base.push!(g::Axis, p::Plot)
     push!(g.plots, p)
@@ -612,7 +612,7 @@ function plot(axis::Axis)
     print(o, "\\begin{$(axis.axisKeyword)}")
     plotHelper(o, axis)
     println(o, "\\end{$(axis.axisKeyword)}")
-    TikzPicture(takebuf_string(o), options=pgfplotsoptions(), preamble=pgfplotspreamble())
+    TikzPicture(String(take!(o)), options=pgfplotsoptions(), preamble=pgfplotspreamble())
 end
 
 function plot(axes::Axes)
@@ -623,7 +623,7 @@ function plot(axes::Axes)
         plotHelper(o, axis)
         println(o, "\\end{$(axis.axisKeyword)}")
     end
-    TikzPicture(takebuf_string(o), options=pgfplotsoptions(), preamble=pgfplotspreamble())
+    TikzPicture(String(take!(o)), options=pgfplotsoptions(), preamble=pgfplotspreamble())
 end
 
 function plot(p::GroupPlot)
@@ -643,10 +643,10 @@ function plot(p::GroupPlot)
     end
     println(o, "\\end{groupplot}")
     mypreamble = pgfplotspreamble() * "\\usepgfplotslibrary{groupplots}"
-    TikzPicture(takebuf_string(o), options=pgfplotsoptions(), preamble=mypreamble)
+    TikzPicture(String(take!(o)), options=pgfplotsoptions(), preamble=mypreamble)
 end
 
-typealias Plottable Union{Plot,GroupPlot,Axis,Axes,TikzPicture}
+const Plottable = Union{Plot,GroupPlot,Axis,Axes,TikzPicture}
 
 plot(p::Plot) = plot(Axis(p))
 
@@ -698,7 +698,7 @@ function colormapOptions(cm::ColorMaps.RGBArrayMap)
         print(o, "rgb($(i-1)cm)=($(c.r),$(c.g),$(c.b)) ")
     end
     print(o, "}")
-    takebuf_string(o)
+    String(take!(o))
 end
 
 function axisOptions(p::Image)

--- a/src/colormaps.jl
+++ b/src/colormaps.jl
@@ -5,8 +5,9 @@ import Images: colorview, save, Gray, ImageMeta
 import Colors: RGB, distinguishable_colors, colormap
 import ColorBrewer: palette
 import IndirectArrays: IndirectArray
+using Compat
 
-abstract ColorMap
+@compat abstract type ColorMap end
 
 type GrayMap <: ColorMap
     invert::Bool
@@ -61,7 +62,7 @@ end
 Base.write(colormap::ColorMap, data, filename) = error("Not supported")
 
 function Base.write(colormap::RGBArrayMap, data, filename)
-    img = ImageMeta(IndirectArray(round(UInt8, 1.+(length(colormap.colors)-1).*(data)), colormap.colors))
+    img = ImageMeta(IndirectArray([round(UInt8, v) for v in 1.+(length(colormap.colors)-1).*(data)], colormap.colors))
     save(filename, img)
 end
 

--- a/src/plots.jl
+++ b/src/plots.jl
@@ -7,11 +7,11 @@ using Compat
 using Discretizers
 using StatsBase
 
-typealias RealRange @compat Tuple{Real,Real}
+const RealRange = @compat Tuple{Real,Real}
 
 include("ndgrid.jl")
 
-abstract Plot
+@compat abstract type Plot end
 
 type Linear <: Plot
     data::AbstractMatrix{Real}
@@ -204,7 +204,7 @@ type Image <: Plot
             zmin -= 1.
             zmax += 1.
         end
-        A = clamp(A, zmin, zmax)
+        A = clamp.(A, zmin, zmax)
         A = A .- zmin
         A = A ./ (zmax - zmin)
         if isa(colormap, ColorMaps.ColorMap)
@@ -260,7 +260,7 @@ function Histogram2{A<:Real, B<:Real, C<:Real}(x::Vector{A}, y::Vector{B}, edges
     n = length(ey)-1
     scale =  m*n / ((ex[end]-ex[1]) * (ey[end]-ey[1]) * sum(M))
 
-    patchdata = Array(Float64, 3, 4*n*m)
+    patchdata = Array{Float64}(3, 4*n*m)
     patchidx = 0
     for i in 1 : m
         x₁, x₂ = ex[i], ex[i+1]


### PR DESCRIPTION
Wrapping ALL of PGFPlots is likely far away, this provides an escape hatch to inject arbitrary options into an axis:

![image](https://cloud.githubusercontent.com/assets/1282691/25221202/85f0a9b8-25b4-11e7-8528-30b44e8594ff.png)

This PR also fixes the deprecation warnings for 0.6.
