### PR TITLE
remove precompilation

### DIFF
--- a/src/PGFPlots.jl
+++ b/src/PGFPlots.jl
@@ -1,5 +1,3 @@
-__precompile__(true)
-
 module PGFPlots
 
 export LaTeXString, @L_str, @L_mstr


### PR DESCRIPTION
Since not all dependencies enable precompilation, this shouldn't be here. I was wrong adding it. I am seeing some precompilation problems with current PGFPlots which is perhaps caused by this.